### PR TITLE
fix: resolve panic in report screen and improve CLI consistency

### DIFF
--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -20,13 +20,13 @@ var (
 
 var logsCmd = &cobra.Command{
 	Use:   "logs",
-	Short: "View kar98k logs",
-	Long: `View logs from the kar98k daemon.
+	Short: "View kar logs",
+	Long: `View logs from the kar daemon.
 
 Examples:
-  kar98k logs          Show recent logs
-  kar98k logs -f       Follow logs in real-time
-  kar98k logs -n 50    Show last 50 lines`,
+  kar logs          Show recent logs
+  kar logs -f       Follow logs in real-time
+  kar logs -n 50    Show last 50 lines`,
 	RunE: runLogs,
 }
 
@@ -43,7 +43,7 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	if _, err := os.Stat(logPath); os.IsNotExist(err) {
 		fmt.Println()
 		fmt.Println(tui.WarningStyle.Render("  No logs found"))
-		fmt.Println(tui.DimStyle.Render("  kar98k may not have been started yet"))
+		fmt.Println(tui.DimStyle.Render("  kar may not have been started yet"))
 		fmt.Println()
 		return nil
 	}
@@ -55,7 +55,7 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	defer file.Close()
 
 	fmt.Println()
-	fmt.Println(tui.TitleStyle.Render(" kar98k logs "))
+	fmt.Println(tui.TitleStyle.Render(" kar logs "))
 	fmt.Println(tui.DimStyle.Render(fmt.Sprintf(" %s", logPath)))
 	fmt.Println(tui.Divider(50))
 	fmt.Println()

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -28,7 +28,7 @@ var rootCmd = &cobra.Command{
     ██║  ██╗██║  ██║██║  ██║ █████╔╝╚█████╔╝██║  ██╗
     ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝ ╚════╝  ╚════╝ ╚═╝  ╚═╝
 
-kar98k is a high-intensity irregular traffic simulation service.
+kar is a high-intensity irregular traffic simulation service.
 Generate realistic, unpredictable traffic patterns for load testing.
 
 Commands:
@@ -46,7 +46,7 @@ Commands:
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show version information",
-	Long:  `Display detailed version information about kar98k.`,
+	Long:  `Display detailed version information about kar.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		printVersion()
 	},

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -19,18 +19,18 @@ var (
 
 var runCmd = &cobra.Command{
 	Use:   "run",
-	Short: "Run kar98k with a config file (headless mode)",
-	Long: `Run kar98k in headless mode using a YAML configuration file.
+	Short: "Run kar with a config file (headless mode)",
+	Long: `Run kar in headless mode using a YAML configuration file.
 This is useful for server deployments or CI/CD pipelines.
 
 Example:
-  kar98k run --config kar98k.yaml
-  kar98k run --config kar98k.yaml --trigger`,
+  kar run --config kar.yaml
+  kar run --config kar.yaml --trigger`,
 	RunE: runRun,
 }
 
 func init() {
-	runCmd.Flags().StringVarP(&configPath, "config", "c", "kar98k.yaml", "Path to configuration file")
+	runCmd.Flags().StringVarP(&configPath, "config", "c", "kar.yaml", "Path to configuration file")
 	runCmd.Flags().BoolVarP(&daemonMode, "daemon", "d", false, "Run as background daemon")
 	runCmd.Flags().BoolVarP(&autoTrigger, "trigger", "t", false, "Auto-trigger on start")
 	rootCmd.AddCommand(runCmd)
@@ -39,7 +39,7 @@ func init() {
 func runRun(cmd *cobra.Command, args []string) error {
 	// Check if already running
 	if daemon.IsRunning() && !daemonMode {
-		fmt.Println("\n⚠️  kar98k is already running!")
+		fmt.Println("\n⚠️  kar is already running!")
 		return nil
 	}
 
@@ -49,7 +49,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
-	fmt.Printf("⌖ kar98k starting (config: %s)\n", configPath)
+	fmt.Printf("⌖ kar starting (config: %s)\n", configPath)
 	fmt.Printf("  Targets: %d\n", len(cfg.Targets))
 	fmt.Printf("  Base TPS: %.0f\n", cfg.Controller.BaseTPS)
 	fmt.Printf("  Max TPS: %.0f\n", cfg.Controller.MaxTPS)
@@ -72,7 +72,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 		d.Trigger()
 	} else {
 		fmt.Println("⏸  Waiting for trigger...")
-		fmt.Println("   Use 'kar98k trigger' to start traffic")
+		fmt.Println("   Use 'kar trigger' to start traffic")
 	}
 
 	// Wait for shutdown signal

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -35,6 +35,12 @@ func runStart(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Initialize logger
+	if err := tui.InitLogger(); err != nil {
+		return fmt.Errorf("failed to init logger: %w", err)
+	}
+	defer tui.CloseLogger()
+
 	// Run the TUI
 	m := tui.NewModel()
 	p := tea.NewProgram(m, tea.WithAltScreen())

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -15,8 +15,8 @@ import (
 
 var startCmd = &cobra.Command{
 	Use:   "start",
-	Short: "Launch interactive configuration and start kar98k",
-	Long: `Launch the interactive TUI to configure kar98k.
+	Short: "Launch interactive configuration and start kar",
+	Long: `Launch the interactive TUI to configure kar.
 Walk through target setup, traffic configuration, and pattern settings,
 then pull the trigger to start generating traffic.`,
 	RunE: runStart,
@@ -29,9 +29,9 @@ func init() {
 func runStart(cmd *cobra.Command, args []string) error {
 	// Check if already running
 	if daemon.IsRunning() {
-		fmt.Println("\n⚠️  kar98k is already running!")
-		fmt.Println("   Use 'kar98k status' to check status")
-		fmt.Println("   Use 'kar98k stop' to stop the running instance")
+		fmt.Println("\n⚠️  kar is already running!")
+		fmt.Println("   Use 'kar status' to check status")
+		fmt.Println("   Use 'kar stop' to stop the running instance")
 		return nil
 	}
 
@@ -58,18 +58,18 @@ func runStart(cmd *cobra.Command, args []string) error {
 	cfg := buildConfigFromTUI(tuiConfig)
 
 	// Start daemon in background
-	fmt.Println("\n🚀 Starting kar98k daemon...")
+	fmt.Println("\n🚀 Starting kar daemon...")
 
 	// Fork to background
 	if err := startDaemon(cfg); err != nil {
 		return fmt.Errorf("failed to start daemon: %w", err)
 	}
 
-	fmt.Println("✅ kar98k is now running in the background!")
+	fmt.Println("✅ kar is now running in the background!")
 	fmt.Println("")
-	fmt.Println("   📊 Status:  kar98k status")
-	fmt.Println("   📜 Logs:    kar98k logs -f")
-	fmt.Println("   🛑 Stop:    kar98k stop")
+	fmt.Println("   📊 Status:  kar status")
+	fmt.Println("   📜 Logs:    kar logs -f")
+	fmt.Println("   🛑 Stop:    kar stop")
 	fmt.Println("")
 
 	return nil

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -19,13 +19,13 @@ var (
 
 var statusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Show kar98k status",
-	Long: `Display the current status of the kar98k daemon.
+	Short: "Show kar status",
+	Long: `Display the current status of the kar daemon.
 
 Examples:
-  kar98k status          Show current status
-  kar98k status -w       Watch status (refresh every second)
-  kar98k status --json   Output as JSON`,
+  kar status          Show current status
+  kar status -w       Watch status (refresh every second)
+  kar status --json   Output as JSON`,
 	RunE: runStatus,
 }
 
@@ -47,9 +47,9 @@ func showStatus() error {
 	resp, err := daemon.SendCommand(daemon.Command{Type: "status"})
 	if err != nil {
 		fmt.Println()
-		fmt.Println(tui.ErrorStyle.Render("  ✗ kar98k is not running"))
+		fmt.Println(tui.ErrorStyle.Render("  ✗ kar is not running"))
 		fmt.Println()
-		fmt.Println(tui.DimStyle.Render("  Start with: kar98k start"))
+		fmt.Println(tui.DimStyle.Render("  Start with: kar start"))
 		fmt.Println()
 		return nil
 	}

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -1,10 +1,15 @@
 package cli
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
 	"time"
 
-	"github.com/kar98k/internal/daemon"
 	"github.com/kar98k/internal/tui"
 	"github.com/spf13/cobra"
 )
@@ -22,36 +27,98 @@ func init() {
 }
 
 func runStop(cmd *cobra.Command, args []string) error {
-	if !daemon.IsRunning() {
+	pidPath := filepath.Join(os.TempDir(), "kar98k", "kar98k.pid")
+	logPath := filepath.Join(os.TempDir(), "kar98k", "kar98k.log")
+
+	// Read PID file
+	pidData, err := os.ReadFile(pidPath)
+	if err != nil {
 		fmt.Println()
 		fmt.Println(tui.WarningStyle.Render("  kar is not running"))
 		fmt.Println()
 		return nil
 	}
 
-	fmt.Println()
-	fmt.Print(tui.InfoStyle.Render("  Stopping kar"))
-
-	resp, err := daemon.SendCommand(daemon.Command{Type: "stop"})
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidData)))
 	if err != nil {
-		// Connection closed means daemon stopped
 		fmt.Println()
-		fmt.Println(tui.SuccessStyle.Render("  " + tui.CheckMark + " kar stopped"))
+		fmt.Println(tui.ErrorStyle.Render("  Invalid PID file"))
 		fmt.Println()
 		return nil
 	}
 
-	if resp.Success {
-		// Wait a moment for daemon to fully stop
-		time.Sleep(500 * time.Millisecond)
+	// Check if process exists
+	process, err := os.FindProcess(pid)
+	if err != nil {
 		fmt.Println()
-		fmt.Println(tui.SuccessStyle.Render("  " + tui.CheckMark + " kar stopped"))
+		fmt.Println(tui.WarningStyle.Render("  kar is not running"))
 		fmt.Println()
-	} else {
-		fmt.Println()
-		fmt.Println(tui.ErrorStyle.Render("  " + resp.Message))
-		fmt.Println()
+		os.Remove(pidPath)
+		return nil
 	}
 
+	fmt.Println()
+	fmt.Println(tui.InfoStyle.Render("  Stopping kar (PID: " + strconv.Itoa(pid) + ")..."))
+
+	// Send SIGTERM
+	if err := process.Signal(syscall.SIGTERM); err != nil {
+		// Process already finished, clean up PID file
+		os.Remove(pidPath)
+		fmt.Println(tui.SuccessStyle.Render("  " + tui.CheckMark + " kar stopped (was already finished)"))
+		fmt.Println()
+		showLastSummary(logPath)
+		return nil
+	}
+
+	// Wait for process to exit (max 5 seconds)
+	for i := 0; i < 50; i++ {
+		time.Sleep(100 * time.Millisecond)
+		if _, err := os.Stat(pidPath); os.IsNotExist(err) {
+			break
+		}
+	}
+
+	fmt.Println(tui.SuccessStyle.Render("  " + tui.CheckMark + " kar stopped"))
+	fmt.Println()
+
+	// Show last summary from log
+	showLastSummary(logPath)
+
 	return nil
+}
+
+// showLastSummary reads the log file and displays the last SUMMARY line
+func showLastSummary(logPath string) {
+	file, err := os.Open(logPath)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	var lastSummary string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "SUMMARY:") {
+			lastSummary = line
+		}
+	}
+
+	if lastSummary != "" {
+		fmt.Println(tui.SubtitleStyle.Render("  Last Session Summary:"))
+		// Parse and format summary
+		if idx := strings.Index(lastSummary, "SUMMARY:"); idx != -1 {
+			summary := lastSummary[idx+9:]
+			parts := strings.Fields(summary)
+			for _, part := range parts {
+				kv := strings.Split(part, "=")
+				if len(kv) == 2 {
+					fmt.Printf("    %s: %s\n",
+						tui.LabelStyle.Render(kv[0]),
+						tui.ValueStyle.Render(kv[1]))
+				}
+			}
+		}
+		fmt.Println()
+	}
 }

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -11,8 +11,8 @@ import (
 
 var stopCmd = &cobra.Command{
 	Use:   "stop",
-	Short: "Stop the kar98k daemon",
-	Long: `Stop the running kar98k daemon gracefully.
+	Short: "Stop the kar daemon",
+	Long: `Stop the running kar daemon gracefully.
 This will drain in-flight requests before shutting down.`,
 	RunE: runStop,
 }
@@ -24,19 +24,19 @@ func init() {
 func runStop(cmd *cobra.Command, args []string) error {
 	if !daemon.IsRunning() {
 		fmt.Println()
-		fmt.Println(tui.WarningStyle.Render("  kar98k is not running"))
+		fmt.Println(tui.WarningStyle.Render("  kar is not running"))
 		fmt.Println()
 		return nil
 	}
 
 	fmt.Println()
-	fmt.Print(tui.InfoStyle.Render("  Stopping kar98k"))
+	fmt.Print(tui.InfoStyle.Render("  Stopping kar"))
 
 	resp, err := daemon.SendCommand(daemon.Command{Type: "stop"})
 	if err != nil {
 		// Connection closed means daemon stopped
 		fmt.Println()
-		fmt.Println(tui.SuccessStyle.Render("  " + tui.CheckMark + " kar98k stopped"))
+		fmt.Println(tui.SuccessStyle.Render("  " + tui.CheckMark + " kar stopped"))
 		fmt.Println()
 		return nil
 	}
@@ -45,7 +45,7 @@ func runStop(cmd *cobra.Command, args []string) error {
 		// Wait a moment for daemon to fully stop
 		time.Sleep(500 * time.Millisecond)
 		fmt.Println()
-		fmt.Println(tui.SuccessStyle.Render("  " + tui.CheckMark + " kar98k stopped"))
+		fmt.Println(tui.SuccessStyle.Render("  " + tui.CheckMark + " kar stopped"))
 		fmt.Println()
 	} else {
 		fmt.Println()

--- a/internal/pattern/engine.go
+++ b/internal/pattern/engine.go
@@ -93,6 +93,7 @@ func (e *Engine) IsSpiking() bool {
 type Status struct {
 	BaseTPS           float64
 	MaxTPS            float64
+	CurrentTPS        float64
 	PoissonEnabled    bool
 	PoissonSpiking    bool
 	PoissonMultiplier float64
@@ -105,9 +106,16 @@ func (e *Engine) GetStatus() Status {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
+	// Calculate current TPS (with schedule multiplier = 1.0)
+	currentTPS := e.baseTPS * e.poisson.Multiplier() * e.noise.Multiplier()
+	if currentTPS > e.maxTPS {
+		currentTPS = e.maxTPS
+	}
+
 	return Status{
 		BaseTPS:           e.baseTPS,
 		MaxTPS:            e.maxTPS,
+		CurrentTPS:        currentTPS,
 		PoissonEnabled:    e.poisson.cfg.Enabled,
 		PoissonSpiking:    e.poisson.IsSpiking(),
 		PoissonMultiplier: e.poisson.Multiplier(),

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -365,7 +365,7 @@ func (m *Model) updateRunningStats() {
 	m.RequestsSent = int64(elapsed * 100)
 	m.ErrorCount = int64(elapsed * 0.5)
 	m.AvgLatency = 15 + float64(m.spinnerFrame%5)
-	m.IsSpiking = m.spinnerFrame%20 < 5
+	m.IsSpiking = m.spinnerFrame%50 < 3 // ~6% spike rate
 
 	// Track peak TPS
 	if m.CurrentTPS > m.peakTPS {
@@ -378,10 +378,10 @@ func (m *Model) updateRunningStats() {
 	m.slotLatencies = append(m.slotLatencies, simulatedLatency)
 
 	// Simulate status codes
-	if m.spinnerFrame%20 == 0 {
-		m.statusCodes[500]++
-	} else if m.spinnerFrame%10 == 0 {
-		m.statusCodes[429]++
+	if m.spinnerFrame%100 == 0 {
+		m.statusCodes[500]++ // ~1% server error
+	} else if m.spinnerFrame%50 == 0 {
+		m.statusCodes[429]++ // ~2% rate limit
 	} else {
 		m.statusCodes[200]++
 	}
@@ -1069,12 +1069,18 @@ func (m Model) renderTimeChart(slots []TimeSlot) string {
 	}
 
 	// X-axis
-	b.WriteString("      " + DimStyle.Render(strings.Repeat("─", chartWidth)))
-	b.WriteString("\n")
-	b.WriteString(fmt.Sprintf("      %s%s%s",
-		DimStyle.Render("start"),
-		strings.Repeat(" ", chartWidth-9),
-		DimStyle.Render("end")))
+	if chartWidth > 0 {
+		b.WriteString("      " + DimStyle.Render(strings.Repeat("─", chartWidth)))
+		b.WriteString("\n")
+		spacing := chartWidth - 9
+		if spacing < 0 {
+			spacing = 0
+		}
+		b.WriteString(fmt.Sprintf("      %s%s%s",
+			DimStyle.Render("start"),
+			strings.Repeat(" ", spacing),
+			DimStyle.Render("end")))
+	}
 
 	return b.String()
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -491,15 +491,19 @@ func (m Model) viewTargetSetup() string {
 	content := lipgloss.JoinVertical(lipgloss.Left,
 		LabelStyle.Render("Target URL"),
 		m.renderInput(0, m.focusIndex == 0),
+		DimStyle.Render("  The endpoint to test. Include full path."),
+		DimStyle.Render("  ex) http://localhost:8080/api/health"),
 		"",
 		LabelStyle.Render("HTTP Method"),
 		m.renderInput(1, m.focusIndex == 1),
+		DimStyle.Render("  GET: read data, POST: create, PUT: update, DELETE: remove"),
 		"",
-		LabelStyle.Render("Protocol (http/http2/grpc)"),
+		LabelStyle.Render("Protocol"),
 		m.renderInput(2, m.focusIndex == 2),
+		DimStyle.Render("  http: HTTP/1.1, http2: HTTP/2, grpc: gRPC protocol"),
 	)
 
-	box := BorderStyle.Width(60).Render(content)
+	box := BorderStyle.Width(65).Render(content)
 	b.WriteString(lipgloss.Place(m.width, m.height-15, lipgloss.Center, lipgloss.Top, box))
 
 	b.WriteString("\n\n")
@@ -519,14 +523,18 @@ func (m Model) viewTrafficConfig() string {
 	content := lipgloss.JoinVertical(lipgloss.Left,
 		LabelStyle.Render("Base TPS (Transactions Per Second)"),
 		m.renderInput(3, m.focusIndex == 0),
-		DimStyle.Render("  The baseline traffic rate"),
+		DimStyle.Render("  Normal traffic rate. This is your baseline load."),
+		DimStyle.Render("  ex) 100 = 100 requests/sec (6,000 req/min)"),
+		DimStyle.Render("  ex) 500 = 500 requests/sec (30,000 req/min)"),
 		"",
 		LabelStyle.Render("Max TPS"),
 		m.renderInput(4, m.focusIndex == 1),
-		DimStyle.Render("  Maximum TPS cap during spikes"),
+		DimStyle.Render("  Upper limit during spike events."),
+		DimStyle.Render("  ex) Base=100, Max=1000 -> spikes can reach 10x"),
+		DimStyle.Render("  ex) Base=100, Max=300  -> spikes capped at 3x"),
 	)
 
-	box := BorderStyle.Width(60).Render(content)
+	box := BorderStyle.Width(65).Render(content)
 	b.WriteString(lipgloss.Place(m.width, m.height-15, lipgloss.Center, lipgloss.Top, box))
 
 	b.WriteString("\n\n")
@@ -546,23 +554,32 @@ func (m Model) viewPatternConfig() string {
 	content := lipgloss.JoinVertical(lipgloss.Left,
 		LabelStyle.Render("Poisson Lambda (spike frequency)"),
 		m.renderInput(5, m.focusIndex == 0),
-		DimStyle.Render("  Average spikes per second (e.g., 0.1)"),
+		DimStyle.Render("  How often spikes occur (events per second)."),
+		DimStyle.Render("  ex) 0.1  = spike every ~10 sec (rare)"),
+		DimStyle.Render("  ex) 0.5  = spike every ~2 sec (frequent)"),
+		DimStyle.Render("  ex) 0.02 = spike every ~50 sec (very rare)"),
 		"",
 		LabelStyle.Render("Spike Factor (TPS multiplier)"),
 		m.renderInput(6, m.focusIndex == 1),
-		DimStyle.Render("  How much TPS increases during spikes"),
+		DimStyle.Render("  TPS multiplier when spike occurs."),
+		DimStyle.Render("  ex) 2.0 = 2x during spike (100 -> 200 TPS)"),
+		DimStyle.Render("  ex) 5.0 = 5x during spike (100 -> 500 TPS)"),
 		"",
 		LabelStyle.Render("Noise Amplitude"),
 		m.renderInput(7, m.focusIndex == 2),
-		DimStyle.Render("  Random fluctuation range (0.15 = ±15%)"),
+		DimStyle.Render("  Random fluctuation around base TPS."),
+		DimStyle.Render("  ex) 0.1  = +/-10% (90~110 when base=100)"),
+		DimStyle.Render("  ex) 0.3  = +/-30% (70~130 when base=100)"),
 		"",
-		LabelStyle.Render("Schedule (optional: hour-range:multiplier)"),
+		LabelStyle.Render("Schedule (optional)"),
 		m.renderInput(8, m.focusIndex == 3),
-		DimStyle.Render("  e.g., 9-17:1.5, 0-5:0.3"),
+		DimStyle.Render("  Time-based TPS multiplier. Format: hour-hour:factor"),
+		DimStyle.Render("  ex) 9-18:1.5  = 1.5x during 9AM-6PM"),
+		DimStyle.Render("  ex) 0-6:0.3   = 0.3x during midnight-6AM"),
 	)
 
-	box := BorderStyle.Width(60).Render(content)
-	b.WriteString(lipgloss.Place(m.width, m.height-18, lipgloss.Center, lipgloss.Top, box))
+	box := BorderStyle.Width(65).Render(content)
+	b.WriteString(lipgloss.Place(m.width, m.height-22, lipgloss.Center, lipgloss.Top, box))
 
 	b.WriteString("\n\n")
 	b.WriteString(lipgloss.Place(m.width, 0, lipgloss.Center, lipgloss.Top,

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -157,17 +157,17 @@ func ProgressBar(percent float64, width int) string {
 
 	bar := ""
 	for i := 0; i < filled; i++ {
-		bar += "█"
+		bar += "="
 	}
 	for i := 0; i < empty; i++ {
-		bar += "░"
+		bar += "-"
 	}
 
 	return ProgressBarStyle.Render(bar[:filled]) + ProgressEmptyStyle.Render(bar[filled:])
 }
 
-// Spinner frames for loading animation
-var SpinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+// Spinner frames for loading animation (ASCII compatible)
+var SpinnerFrames = []string{"|", "/", "-", "\\", "|", "/", "-", "\\", "|", "/"}
 
 // Bullet points
 const (


### PR DESCRIPTION
## Summary
- Fix `strings.Repeat` negative count panic when rendering time chart in report screen
- Reduce spike rate from 25% to ~6% for more realistic traffic simulation
- Reduce simulated error rates (500 errors: ~1%, 429 rate limit: ~2%)
- Update all CLI help messages and prompts from `kar98k` to `kar` for consistency

### cli view improve

<img width="653" height="578" alt="image" src="https://github.com/user-attachments/assets/7a454afb-efeb-44e5-83d4-a38647c6259b" />

### `kar logs -f`

<img width="779" height="571" alt="image" src="https://github.com/user-attachments/assets/e5720eeb-0eae-4375-b15d-9e6915a93d00" />



## Test plan
- [x] Build passes (`make build`)
- [x] Echo server runs correctly (`make run-server`)
- [ ] Run `kar start` and complete TUI flow
- [ ] Press Q during running screen to verify report renders without panic
- [ ] Verify CLI messages show `kar` instead of `kar98k`

🤖 Generated with [Claude Code](https://claude.com/claude-code)