### PR TITLE
feat: add spike interval and manual spike trigger

### DIFF
--- a/internal/cli/spike.go
+++ b/internal/cli/spike.go
@@ -1,0 +1,141 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/kar98k/internal/tui"
+	"github.com/spf13/cobra"
+)
+
+var (
+	spikeFactor   float64
+	spikeDuration string
+)
+
+var spikeCmd = &cobra.Command{
+	Use:   "spike",
+	Short: "Trigger a manual spike on running kar instance",
+	Long: `Trigger a manual spike on the running kar instance.
+
+Examples:
+  kar spike                         # Use default spike factor
+  kar spike --factor 5.0            # 5x TPS multiplier
+  kar spike --duration 1m           # Spike for 1 minute
+  kar spike --factor 3.0 --duration 30s`,
+	RunE: runSpike,
+}
+
+func init() {
+	spikeCmd.Flags().Float64VarP(&spikeFactor, "factor", "f", 0, "TPS multiplier (default: uses configured spike_factor)")
+	spikeCmd.Flags().StringVarP(&spikeDuration, "duration", "d", "", "Spike duration (e.g., 30s, 1m, 5m)")
+	rootCmd.AddCommand(spikeCmd)
+}
+
+// SpikeCommand represents a spike command to be sent to the running kar instance
+type SpikeCommand struct {
+	Type     string        `json:"type"`
+	Factor   float64       `json:"factor,omitempty"`
+	Duration time.Duration `json:"duration,omitempty"`
+}
+
+func runSpike(cmd *cobra.Command, args []string) error {
+	pidPath := filepath.Join(os.TempDir(), "kar98k", "kar98k.pid")
+	cmdPath := filepath.Join(os.TempDir(), "kar98k", "kar98k.cmd")
+
+	// Check if kar is running
+	pidData, err := os.ReadFile(pidPath)
+	if err != nil {
+		fmt.Println()
+		fmt.Println(tui.WarningStyle.Render("  kar is not running"))
+		fmt.Println(tui.DimStyle.Render("  Start kar first with: kar start"))
+		fmt.Println()
+		return nil
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidData)))
+	if err != nil {
+		fmt.Println()
+		fmt.Println(tui.ErrorStyle.Render("  Invalid PID file"))
+		fmt.Println()
+		return nil
+	}
+
+	// Check if process exists
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		fmt.Println()
+		fmt.Println(tui.WarningStyle.Render("  kar is not running"))
+		fmt.Println()
+		os.Remove(pidPath)
+		return nil
+	}
+
+	// Verify process is actually running
+	if err := process.Signal(syscall.Signal(0)); err != nil {
+		fmt.Println()
+		fmt.Println(tui.WarningStyle.Render("  kar is not running"))
+		fmt.Println()
+		os.Remove(pidPath)
+		return nil
+	}
+
+	// Parse duration
+	var duration time.Duration
+	if spikeDuration != "" {
+		duration, err = time.ParseDuration(spikeDuration)
+		if err != nil {
+			fmt.Println()
+			fmt.Println(tui.ErrorStyle.Render("  Invalid duration format: " + spikeDuration))
+			fmt.Println(tui.DimStyle.Render("  Use formats like: 30s, 1m, 5m, 1h"))
+			fmt.Println()
+			return nil
+		}
+	}
+
+	// Create spike command
+	spikeCmd := SpikeCommand{
+		Type:     "spike",
+		Factor:   spikeFactor,
+		Duration: duration,
+	}
+
+	// Write command to file
+	cmdData, _ := json.Marshal(spikeCmd)
+	if err := os.WriteFile(cmdPath, cmdData, 0644); err != nil {
+		fmt.Println()
+		fmt.Println(tui.ErrorStyle.Render("  Failed to send spike command"))
+		fmt.Println()
+		return nil
+	}
+
+	// Send SIGUSR1 to notify kar about new command (Unix only)
+	if err := process.Signal(signalUSR1); err != nil {
+		fmt.Println()
+		fmt.Println(tui.ErrorStyle.Render("  Failed to signal kar process"))
+		fmt.Println()
+		return nil
+	}
+
+	fmt.Println()
+	fmt.Println(tui.SuccessStyle.Render("  " + tui.CheckMark + " Manual spike triggered!"))
+	if spikeFactor > 0 {
+		fmt.Println(tui.InfoStyle.Render(fmt.Sprintf("    Factor: %.1fx", spikeFactor)))
+	} else {
+		fmt.Println(tui.DimStyle.Render("    Factor: using configured spike_factor"))
+	}
+	if duration > 0 {
+		fmt.Println(tui.InfoStyle.Render(fmt.Sprintf("    Duration: %s", duration)))
+	} else {
+		fmt.Println(tui.DimStyle.Render("    Duration: using default"))
+	}
+	fmt.Println()
+
+	return nil
+}

--- a/internal/cli/spike_unix.go
+++ b/internal/cli/spike_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package cli
+
+import (
+	"syscall"
+)
+
+var signalUSR1 = syscall.SIGUSR1

--- a/internal/cli/spike_windows.go
+++ b/internal/cli/spike_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package cli
+
+import (
+	"os"
+)
+
+// Windows doesn't have SIGUSR1, use a dummy signal that won't be used
+var signalUSR1 = os.Interrupt

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,7 +57,8 @@ type Pattern struct {
 // Poisson configures Poisson spike generation.
 type Poisson struct {
 	Enabled     bool          `yaml:"enabled"`
-	Lambda      float64       `yaml:"lambda"`
+	Lambda      float64       `yaml:"lambda"`                // Events per second (e.g., 0.1 = every 10s)
+	Interval    time.Duration `yaml:"interval,omitempty"`    // Alternative to lambda: direct interval (e.g., "2h")
 	SpikeFactor float64       `yaml:"spike_factor"`
 	MinInterval time.Duration `yaml:"min_interval"`
 	MaxInterval time.Duration `yaml:"max_interval"`

--- a/internal/pattern/engine.go
+++ b/internal/pattern/engine.go
@@ -2,6 +2,7 @@ package pattern
 
 import (
 	"sync"
+	"time"
 
 	"github.com/kar98k/internal/config"
 )
@@ -87,6 +88,16 @@ func (e *Engine) GetMaxTPS() float64 {
 // IsSpiking returns whether a Poisson spike is active.
 func (e *Engine) IsSpiking() bool {
 	return e.poisson.IsSpiking()
+}
+
+// TriggerManualSpike triggers a manual spike with optional custom factor and duration.
+func (e *Engine) TriggerManualSpike(factor float64, duration time.Duration) {
+	e.poisson.TriggerManualSpike(factor, duration)
+}
+
+// IsManualSpike returns whether a manual spike is currently active.
+func (e *Engine) IsManualSpike() bool {
+	return e.poisson.IsManualSpike()
 }
 
 // Status returns the current status of all pattern generators.


### PR DESCRIPTION
## Summary

- **Issue #14**: Support longer spike intervals with intuitive duration format
- **Issue #15**: Add manual spike trigger command (`kar spike`)

## Changes

### Spike Interval (Issue #14)
- Add `Interval` field to Poisson config accepting Go duration format
- TUI Pattern Configuration now shows "Spike Interval" as primary input
- Examples: `10s`, `5m`, `2h` instead of calculating lambda values
- Lambda kept as optional advanced override for power users

### Manual Spike Trigger (Issue #15)
- New `kar spike` command to trigger spikes on running kar instance
- Options: `--factor` (TPS multiplier), `--duration` (spike length)
- Uses SIGUSR1 signal on Unix systems
- TUI shows `◉ MANUAL SPIKE (3.0x)` indicator
- Events logged to kar98k.log

## Usage

```bash
# Intuitive interval in TUI
Spike Interval: 2h    # spike every ~2 hours

# Manual spike trigger
kar spike                         # default factor
kar spike --factor 5.0            # 5x TPS
kar spike --duration 1m           # 1 minute spike
kar spike --factor 3.0 --duration 30s
```

## Test plan
- [x] `make build` passes
- [x] `make build-all` passes (Linux/macOS/Windows)
- [x] `kar spike --help` shows correct usage
- [x] `kar spike` without running kar shows appropriate error

Closes #14, Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)